### PR TITLE
feat: isolate proxy environment and disable SDK built-in tools

### DIFF
--- a/server/env-setup.ts
+++ b/server/env-setup.ts
@@ -1,0 +1,71 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+
+/**
+ * プロキシ用の隔離された環境を構築する。
+ * 
+ * - ~/.gemini の認証情報などを /tmp にシンボリックリンクする
+ * - GEMINI.md や settings.json の環境固有設定を読み込ませないようにする
+ * - process.env.HOME を一時ディレクトリに書き換える
+ */
+export function setupProxyEnv() {
+  const username = os.userInfo().username;
+  const proxyHome = path.join(os.tmpdir(), `claude2gemini-env-${username}`);
+  const proxyGemini = path.join(proxyHome, '.gemini');
+
+  if (!fs.existsSync(proxyGemini)) {
+    fs.mkdirSync(proxyGemini, { recursive: true });
+  }
+
+  const realHome = os.homedir();
+  const realGemini = path.join(realHome, '.gemini');
+
+  // ~/.gemini ディレクトリが存在すれば、認証関連のファイルをシンボリックリンクする
+  if (fs.existsSync(realGemini)) {
+    const files = fs.readdirSync(realGemini);
+    for (const file of files) {
+      if (file === 'GEMINI.md' || file === 'settings.json') {
+        continue;
+      }
+
+      const src = path.join(realGemini, file);
+      const dest = path.join(proxyGemini, file);
+
+      if (!fs.existsSync(dest)) {
+        try {
+          const stat = fs.statSync(src);
+          // Windows などでの互換性のため symlinkType を指定するなら 'dir' / 'file' を切り替える
+          const type = stat.isDirectory() ? 'dir' : 'file';
+          fs.symlinkSync(src, dest, type);
+        } catch (error) {
+          console.warn(`[Proxy Env] Failed to symlink ${file}:`, error instanceof Error ? error.message : String(error));
+        }
+      }
+    }
+  }
+
+  // 組み込みツールとスキルの無効化を補助するため、ダミーの settings.json を配置する
+  const configDest = path.join(proxyGemini, 'settings.json');
+  if (!fs.existsSync(configDest)) {
+    try {
+      const settings = {
+        tools: {
+          core: [],
+        },
+        skills: {
+          enabled: false,
+        },
+        experimental: {
+          enableAgents: false,
+        },
+      };
+      fs.writeFileSync(configDest, JSON.stringify(settings, null, 2));
+    } catch (error) {
+      console.warn(`[Proxy Env] Failed to write settings.json:`, error);
+    }
+  }
+
+  console.log(`[Proxy] Overriding HOME to virtual directory: ${proxyHome}`);
+  process.env.HOME = proxyHome;
+}

--- a/server/gemini-backend.ts
+++ b/server/gemini-backend.ts
@@ -71,23 +71,89 @@ function createAgent(options: GeminiBackendOptions, toolState: ToolState, sessio
   return new GeminiCliAgent({
     instructions: options.instructions || 'You are a helpful assistant.',
     model: options.model,
-    cwd: options.cwd || process.cwd(),
+    // proxy ホーム（仮想環境）を cwd とする。存在しない場合は process.cwd() をフォールバック。
+    cwd: options.cwd || process.env.HOME || process.cwd(),
     tools: sdkTools,
   });
+}
+
+/**
+ * GeminiCliAgent 内部の registry から、クライアント指定ツール以外の組み込みツールを消去するハック
+ * さらに、もしツール配列が空になった場合、API送信時に invalid proto エラーになるため、
+ * リクエスト送信直前でリクエストから tools プロパティを削除するモンキーパッチを適用する。
+ */
+async function disableBuiltinTools(session: GeminiCliSession, allowedToolNames: string[]) {
+  // session の初期化を強制（内部で config や toolRegistry が作られる）
+  await session.initialize();
+
+  // private property へのアクセス
+  const config = (session as any).config;
+  if (config && config.toolRegistry) {
+    const registry = config.toolRegistry;
+    const allTools = [...registry.getAllToolNames()];
+    for (const name of allTools) {
+      if (!allowedToolNames.includes(name)) {
+        console.log(`[Proxy] Unregistering built-in tool: ${name}`);
+        registry.unregisterTool(name);
+      }
+    }
+  }
+
+  // SDK内部の生成器にモンキーパッチを当てて空の [{ functionDeclarations: [] }] を消す
+  try {
+    const client = (session as any).client;
+    if (client) {
+      const generator = client.getContentGeneratorOrFail();
+      if (generator && !generator.__proxyPatched) {
+        // パッチ用ヘルパー関数
+        const removeEmptyTools = (params: any) => {
+          if (params?.config?.tools) {
+            const tools = params.config.tools;
+            if (Array.isArray(tools) && tools.length === 1 && 
+                Array.isArray(tools[0].functionDeclarations) && 
+                tools[0].functionDeclarations.length === 0) {
+              delete params.config.tools;
+            }
+          }
+        };
+
+        const originalGenerateContent = generator.generateContent?.bind(generator);
+        if (originalGenerateContent) {
+          generator.generateContent = async (params: any, promptId: string, role: string) => {
+            removeEmptyTools(params);
+            return originalGenerateContent(params, promptId, role);
+          };
+        }
+
+        const originalGenerateContentStream = generator.generateContentStream?.bind(generator);
+        if (originalGenerateContentStream) {
+          generator.generateContentStream = async function* (params: any, promptId: string, role: string) {
+            removeEmptyTools(params);
+            const stream = await originalGenerateContentStream(params, promptId, role);
+            yield* stream;
+          };
+        }
+
+        generator.__proxyPatched = true;
+      }
+    }
+  } catch (e) {
+    console.error('[Proxy] Failed to apply monkey patch for empty tools', e);
+  }
 }
 
 /**
  * Gemini にプロンプトを送信し、ストリームを直接返す（ストリーミング用）
  * 既存のセッションがあれば再開する。
  */
-export function sendPromptStream(
+export async function sendPromptStream(
   prompt: string,
   options: GeminiBackendOptions = {},
-): {
+): Promise<{
   stream: AsyncGenerator<ServerGeminiStreamEvent, any, any>;
   toolState: ToolState;
   sessionId: string;
-} {
+}> {
   const sessionId = options.sessionId || `session_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
 
   // 既存セッションが存在し、ストリームが保持されていれば再利用 (+ tool_result が送信された後)
@@ -106,6 +172,11 @@ export function sendPromptStream(
   const toolState: ToolState = { callIds: new Map(), expectedClientTools: 0, registeredClientTools: 0 };
   const agent = createAgent(options, toolState, sessionId);
   const geminiSession = agent.session();
+  
+  // 組み込みツールの強制無効化
+  const allowedToolNames = options.tools?.map((t) => t.name) || [];
+  await disableBuiltinTools(geminiSession, allowedToolNames);
+
   const stream = geminiSession.sendStream(prompt);
   
   // toolState をセッションに保存（次ターンで再利用するため）
@@ -130,7 +201,7 @@ export async function sendPromptAndCollect(
   prompt: string,
   options: GeminiBackendOptions = {},
 ): Promise<NonStreamingResult> {
-  const { stream, toolState, sessionId } = sendPromptStream(prompt, options);
+  const { stream, toolState, sessionId } = await sendPromptStream(prompt, options);
 
   let fullText = '';
   const toolCalls: ClaudeToolUseBlock[] = [];

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,6 @@
+import { setupProxyEnv } from './env-setup.js';
+setupProxyEnv(); // 他のモジュールが読み込まれる前に環境変数を上書き
+
 import express from 'express';
 import { messagesRouter } from './routes/messages.js';
 
@@ -15,6 +18,15 @@ app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.listen(PORT, () => {
+const server = app.listen(PORT);
+server.on('listening', () => {
   console.log(`Claude2Gemini proxy listening on port ${PORT}`);
+});
+server.on('error', (err: NodeJS.ErrnoException) => {
+  if (err.code === 'EADDRINUSE') {
+    console.error(`[Error] Port ${PORT} is already in use. Is another proxy instance running?`);
+  } else {
+    console.error(`[Error] Failed to start proxy:`, err.message);
+  }
+  process.exit(1);
 });

--- a/server/routes/messages.ts
+++ b/server/routes/messages.ts
@@ -122,7 +122,7 @@ messagesRouter.post('/', async (req: Request, res: Response) => {
       // ストリーミングモード: SSE で返す
       setupSSEHeaders(res);
 
-      const { stream, toolState, sessionId: newSessionId } = sendPromptStream(prompt, {
+      const { stream, toolState, sessionId: newSessionId } = await sendPromptStream(prompt, {
         sessionId,
         instructions: systemPrompt,
         model: mappedModel,


### PR DESCRIPTION
- Add env-setup.ts to create an isolated virtual HOME directory under /tmp with per-user namespacing to prevent config conflicts
- Symlink auth credentials from ~/.gemini while excluding GEMINI.md and settings.json from the real environment
- Write a dummy settings.json to disable core tools, skills, and agents
- Monkey-patch SDK internals to unregister built-in tools and strip empty tool declarations that cause invalid proto errors
- Make sendPromptStream async to support initialization before streaming
- Add EADDRINUSE error handling on server startup