### PR TITLE
feat: improve error handling for stream and message routes, including 429 rate limit detection

### DIFF
--- a/server/converters/stream.ts
+++ b/server/converters/stream.ts
@@ -260,13 +260,12 @@ export async function streamGeminiToClaudeSSE(
 
     // 429 エラーを判別
     const isRateLimit = 
-      errorMsg.includes('429') || 
       errorMsg.includes('QUOTA_EXHAUSTED') || 
       errorMsg.includes('RESOURCE_EXHAUSTED') ||
       (error as any)?.status === 429 ||
       (error as any)?.name === 'TerminalQuotaError';
 
-    const errorType = isRateLimit ? 'overloaded_error' : 'api_error';
+    const errorType = isRateLimit ? 'rate_limit_error' : 'api_error';
     const clientMessage = isRateLimit ? 'Gemini API quota exhausted or rate limit exceeded.' : 'Internal server error';
 
     if (!res.writableEnded) {

--- a/server/routes/messages.ts
+++ b/server/routes/messages.ts
@@ -127,6 +127,7 @@ messagesRouter.post('/', async (req: Request, res: Response) => {
         model: mappedModel,
         tools: body.tools,
       });
+      sessionId = newSessionId; // sessionId を outer scope に反映
 
       const allowedToolNames = body.tools?.map((t) => t.name) || [];
       await streamGeminiToClaudeSSE(stream, res, body.model, toolState, newSessionId, sessionStore, allowedToolNames);
@@ -138,6 +139,7 @@ messagesRouter.post('/', async (req: Request, res: Response) => {
         model: mappedModel,
         tools: body.tools,
       });
+      sessionId = result.sessionId; // sessionId を outer scope に反映
 
       const claudeResponse = buildClaudeResponse({
         text: result.text,
@@ -158,14 +160,13 @@ messagesRouter.post('/', async (req: Request, res: Response) => {
 
     // 429 エラー (クォータ超過等) を判別
     const isRateLimit = 
-      errorMsg.includes('429') || 
       errorMsg.includes('QUOTA_EXHAUSTED') || 
       errorMsg.includes('RESOURCE_EXHAUSTED') ||
       (error as any)?.status === 429 ||
       (error as any)?.name === 'TerminalQuotaError';
 
-    const statusCode = isRateLimit ? 529 : 500;
-    const errorType = isRateLimit ? 'overloaded_error' : 'api_error';
+    const statusCode = isRateLimit ? 429 : 500;
+    const errorType = isRateLimit ? 'rate_limit_error' : 'api_error';
     const clientMessage = isRateLimit ? 'Gemini API quota exhausted or rate limit exceeded.' : 'Internal server error';
 
     if (!res.headersSent) {


### PR DESCRIPTION
## Summary
feat: improve error handling for stream and message routes, including 429 rate limit detection

### Review Feedback Fixes
Based on the code review, the following improvements have been made:
- **Rate Limit Mapping (Review Point #2)**: Fixed the mapping of Gemini resource/quota errors to Anthropic's HTTP 429 / `rate_limit_error` (previously incorrectly mapped to 529).
- **Session Cleanup (Review Point #3)**: Updated the local `sessionId` scope in `messages.ts` to ensure that when a new session is created, its ID is captured. This ensures that `sessionStore.deleteSession(sessionId)` can correctly clean up the session if an error occurs.

### Deferred Items
The following review points have been moved to separate issues for future implementation:
- **Test Framework and New Tests (Review Point #1)**: Created [Issue #3](https://github.com/Masterisk-F/claude2gemini-cli/issues/3)
- **Propagating Token Usage Statistics (Review Point #4)**: Created [Issue #4](https://github.com/Masterisk-F/claude2gemini-cli/issues/4)