### PR TITLE
feat: disable gemini-cli specific system prompts

### DIFF
--- a/server/env-setup.ts
+++ b/server/env-setup.ts
@@ -66,6 +66,26 @@ export function setupProxyEnv() {
     }
   }
 
+  // gemini-cli 固有のシステムプロンプトが LLM に渡らないように各セクションを無効化する
+  const disabledPromptSections = [
+    'agentSkills',
+    'agentContexts',
+    'primaryWorkflows',
+    'planningWorkflow',
+    'operationalGuidelines',
+    'preamble',
+    'coreMandates',
+    'sandbox',
+    'git',
+    'finalReminder',
+    'hookContext',
+  ];
+
+  for (const section of disabledPromptSections) {
+    const envKey = `GEMINI_PROMPT_${section.toUpperCase()}`;
+    process.env[envKey] = '0';
+  }
+
   console.log(`[Proxy] Overriding HOME to virtual directory: ${proxyHome}`);
   process.env.HOME = proxyHome;
 }


### PR DESCRIPTION
Set `GEMINI_PROMPT_{SECTION}` environment variables to '0' to prevent gemini-cli from injecting its own tools (like activate_skill), agents, and workflows into the LLM system prompt. This ensures that only the intended instructions from the Claude compatible API are processed.


In `gemini-cli`, the process of changing the system prompt based on environment variables is located in the following source files.

* `gemini-cli/packages/core/src/prompts/promptProvider.ts`
    Determines whether a prompt is needed for each type.

* `gemini-cli/packages/core/src/prompts/utils.ts`
    Determines whether an environment variable exists:
``` javascript
/**
* Checks if a specific prompt section is enabled via environment variables.
*/
export function isSectionEnabled(key: string): boolean {
const envVar = process.env[`GEMINI_PROMPT_${key.toUpperCase()}`];
const lowerEnvVar = envVar?.trim().toLowerCase();
return lowerEnvVar !== '0' && lowerEnvVar !== 'false';
}
```