### PR TITLE
Introduce Vitest and expand test coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,11 @@
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/node": "^22.0.0",
+        "@types/supertest": "^7.2.0",
+        "supertest": "^7.2.2",
         "tsx": "^4.20.3",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -119,6 +122,106 @@
         "node-pty": "^1.0.0"
       }
     },
+    "gemini-cli/packages/core/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "gemini-cli/packages/core/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "gemini-cli/packages/sdk": {
       "name": "@google/gemini-cli-sdk",
       "version": "0.36.0-nightly.20260317.2f90b4653",
@@ -134,6 +237,106 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "gemini-cli/packages/sdk/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "gemini-cli/packages/sdk/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "gemini-cli/packages/test-utils": {
@@ -152,6 +355,106 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "gemini-cli/packages/test-utils/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "gemini-cli/packages/test-utils/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/@a2a-js/sdk": {
@@ -1299,6 +1602,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@open-draft/deferred-promise": {
@@ -2615,6 +2931,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2727,9 +3053,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -2741,9 +3067,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -2755,9 +3081,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -2769,9 +3095,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -2783,9 +3109,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -2797,9 +3123,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -2811,13 +3137,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2825,13 +3154,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2839,13 +3171,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2853,13 +3188,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2867,13 +3205,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2881,13 +3222,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2895,13 +3239,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2909,13 +3256,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2923,13 +3273,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2937,13 +3290,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2951,13 +3307,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2965,13 +3324,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2979,13 +3341,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2993,9 +3358,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
       "cpu": [
         "x64"
       ],
@@ -3007,9 +3372,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
       "cpu": [
         "arm64"
       ],
@@ -3021,9 +3386,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -3035,9 +3400,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -3049,9 +3414,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -3063,9 +3428,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -3119,6 +3484,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -3171,6 +3543,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -3257,6 +3636,13 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -3333,6 +3719,70 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/superagent/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/superagent/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@types/superagent/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -3367,22 +3817,22 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "4.1.2",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -3391,6 +3841,16 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/pretty-format": {
@@ -3599,6 +4059,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -4148,6 +4615,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -4170,6 +4647,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -4187,6 +4671,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -4393,6 +4884,17 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/diff": {
       "version": "8.0.3",
@@ -4995,6 +5497,13 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -5181,6 +5690,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -6307,6 +6834,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mime": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.7.tgz",
@@ -6749,6 +7286,17 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
       "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -7450,9 +7998,9 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7466,31 +8014,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -8103,6 +8651,95 @@
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
       "license": "MIT"
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/superagent/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/systeminformation": {
       "version": "5.31.5",
       "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
@@ -8678,65 +9315,71 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
           "optional": true
         },
         "@vitest/ui": {
@@ -8747,7 +9390,140 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Claude API compatible proxy backed by Gemini CLI SDK",
   "type": "module",
   "scripts": {
+    "test": "vitest",
     "dev": "tsx server/index.ts",
     "build": "tsc",
     "start": "node dist/server/index.js",
@@ -19,8 +20,11 @@
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
+    "@types/supertest": "^7.2.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.20.3",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.2"
   },
   "engines": {
     "node": ">=20"

--- a/server/child-manager.ts
+++ b/server/child-manager.ts
@@ -1,4 +1,4 @@
-import { fork, type ChildProcess } from 'node:child_process';
+import { fork, spawn, type ChildProcess } from 'node:child_process';
 import net from 'node:net';
 import path from 'node:path';
 import os from 'node:os';
@@ -38,14 +38,26 @@ class ChildManager extends EventEmitter {
         const spawnPromise = (async () => {
             const socketPath = path.join(os.tmpdir(), `c2g-worker-${os.userInfo().username}-${accountId}.sock`);
 
-            // 子プロセスを起動 (tsx 環境であれば自動的に引き継がれる)
-            const child = fork(CHILD_WORKER_SCRIPT, [
-                `--account-id=${accountId}`,
-                `--socket=${socketPath}`
-            ], {
-                // 標準出力・標準エラー出力を親プロセスに引き継ぐ
-                stdio: ['ignore', 'inherit', 'inherit', 'ipc']
-            });
+            // 子プロセスを起動
+            let child: ChildProcess;
+            if (ext === '.ts') {
+                // TypeScript環境の場合は tsx を使用
+                child = spawn('npx', ['tsx', CHILD_WORKER_SCRIPT,
+                    `--account-id=${accountId}`,
+                    `--socket=${socketPath}`
+                ], {
+                    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+                    shell: true // npx を使うために shell: true が必要な場合がある
+                });
+            } else {
+                // ビルド済みの場合は通常の fork
+                child = fork(CHILD_WORKER_SCRIPT, [
+                    `--account-id=${accountId}`,
+                    `--socket=${socketPath}`
+                ], {
+                    stdio: ['ignore', 'inherit', 'inherit', 'ipc']
+                });
+            }
 
             child.on('exit', (code) => {
                 console.error(`[ChildManager] Child worker for ${accountId} exited with code ${code}.`);

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,45 +1,44 @@
 # Tests
 
-このディレクトリは `claude2gemini-cli` プロジェクトのテストコードを格納しています。
-テストフレームワークとして [Vitest](https://vitest.dev/) を使用しています。
+This directory contains the test suite for the `claude2gemini-cli` project. We use [Vitest](https://vitest.dev/) as our primary testing framework.
 
-## テストの実行方法
+## How to Run Tests
 
-プロジェクトルートで以下のコマンドを実行します。
+Execute the following commands from the project root:
 
 ```bash
-# 全てのテストを実行
+# Run all tests
 npm run test
 
-# UIや監視モード（watch）で起動して開発を行う
+# Start Vitest in watch mode (recommended for development)
 npx vitest
 
-# 特定のファイルを指定して実行
+# Run a specific test file
 npx vitest run tests/child-worker.test.ts
 
-# カバレッジを出力しながら実行
+# Run tests and generate coverage report
 npx vitest run --coverage
 ```
 
-## ディレクトリ構成と配置ルール
+## Directory Structure and Conventions
 
-テストファイルは、対象となるソースコードのディレクトリ構造と対応するように配置してください。
+Test files should be placed in the `tests/` directory, reflecting the structure of the source code.
 
-- **`tests/*.test.ts`**: プロジェクトの主要コンポーネント（子プロセス管理、IPC通信など）の統合的なテストや、ルートディレクトリに近いモジュールのテストを配置します。
-  - 例: `child-worker.test.ts` (子プロセスの起動と通信のテスト)
-  - 例: `ipc-protocol.test.ts` (IPCプロトコルのシリアライズ/デシリアライズのテスト)
-  - 例: `process-isolation.test.ts` (マルチアカウント時のプロセス分離のテスト)
-- **`tests/server/converters/*.test.ts`**: `server/converters/` にあるリクエスト/レスポンス変換ロジックの単体テストを配置します。
-- **`tests/server/routes/*.test.ts`**: Expressのルーター機能に対するAPI統合テスト（`supertest`を使用）を配置します。
+- **`tests/*.test.ts`**: Integration tests for core components (child process management, IPC communication) or tests for modules near the root directory.
+  - e.g., `child-worker.test.ts` (Spawning and communicating with child workers)
+  - e.g., `ipc-protocol.test.ts` (Serialization/deserialization of IPC messages)
+  - e.g., `process-isolation.test.ts` (Process isolation when using multiple accounts)
+- **`tests/server/converters/*.test.ts`**: Unit tests for request/response transformation logic located in `server/converters/`.
+- **`tests/server/routes/*.test.ts`**: API integration tests for Express routers using `supertest`.
 
-## テスト追加時のガイドライン
+## Guidelines for Adding Tests
 
-1. **ファイル名と配置**:
-   新しいテストを追加する際は、対象ファイル名に `.test.ts` を付与し、元のソースコードと同じ階層構造になるように `tests/` 内へ配置してください。
-2. **ESM / TypeScript 環境**:
-   当プロジェクトは ESM (`type: "module"`) を使用しています。ローカルファイルのインポート時は、拡張子 `.js` を忘れずに付与してください。（例: `import { example } from '../server/example.js';`）
-3. **VitestのAPI**:
-   テストの記述には `vitest` から `describe`, `it` (または `test`), `expect`, `vi` 等をインポートして使用してください。
+1. **Naming and Placement**:
+   New tests should end with `.test.ts` and be placed in a corresponding subdirectory within `tests/` that mirrors the source file's location.
+2. **ESM / TypeScript Environment**:
+   This project uses ESM (`type: "module"`). When importing local files, remember to include the `.js` extension (e.g., `import { example } from '../server/example.js';`).
+3. **Vitest API**:
+   Import `describe`, `it` (or `test`), `expect`, and `vi` from `vitest` to write your tests.
    ```typescript
    import { describe, it, expect } from 'vitest';
 
@@ -49,6 +48,6 @@ npx vitest run --coverage
      });
    });
    ```
-4. **モック化と非同期処理**:
-   - 外部へのリクエストや子プロセス生成など、副作用を伴うテストでは `vi.mock()` などを利用して適切にモック化してください。
-   - プロセスの起動やIPC通信などの非同期処理を待つ必要がある場合は、テストのタイムアウト時間（デフォルトは5秒）を超えないよう、必要に応じてタイムアウトを長めに設定（`it('...', async () => { ... }, 20000)` のように第3引数でミリ秒指定）してください。
+4. **Mocking and Asynchrony**:
+   - Use `vi.mock()` to isolate your tests from side effects like network requests or child process spawning.
+   - For tests involving process startup or IPC communication, you may need to increase the default timeout (5s). Provide a timeout in milliseconds as the third argument to `it` (e.g., `it('...', async () => { ... }, 20000)`).

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,54 @@
+# Tests
+
+このディレクトリは `claude2gemini-cli` プロジェクトのテストコードを格納しています。
+テストフレームワークとして [Vitest](https://vitest.dev/) を使用しています。
+
+## テストの実行方法
+
+プロジェクトルートで以下のコマンドを実行します。
+
+```bash
+# 全てのテストを実行
+npm run test
+
+# UIや監視モード（watch）で起動して開発を行う
+npx vitest
+
+# 特定のファイルを指定して実行
+npx vitest run tests/child-worker.test.ts
+
+# カバレッジを出力しながら実行
+npx vitest run --coverage
+```
+
+## ディレクトリ構成と配置ルール
+
+テストファイルは、対象となるソースコードのディレクトリ構造と対応するように配置してください。
+
+- **`tests/*.test.ts`**: プロジェクトの主要コンポーネント（子プロセス管理、IPC通信など）の統合的なテストや、ルートディレクトリに近いモジュールのテストを配置します。
+  - 例: `child-worker.test.ts` (子プロセスの起動と通信のテスト)
+  - 例: `ipc-protocol.test.ts` (IPCプロトコルのシリアライズ/デシリアライズのテスト)
+  - 例: `process-isolation.test.ts` (マルチアカウント時のプロセス分離のテスト)
+- **`tests/server/converters/*.test.ts`**: `server/converters/` にあるリクエスト/レスポンス変換ロジックの単体テストを配置します。
+- **`tests/server/routes/*.test.ts`**: Expressのルーター機能に対するAPI統合テスト（`supertest`を使用）を配置します。
+
+## テスト追加時のガイドライン
+
+1. **ファイル名と配置**:
+   新しいテストを追加する際は、対象ファイル名に `.test.ts` を付与し、元のソースコードと同じ階層構造になるように `tests/` 内へ配置してください。
+2. **ESM / TypeScript 環境**:
+   当プロジェクトは ESM (`type: "module"`) を使用しています。ローカルファイルのインポート時は、拡張子 `.js` を忘れずに付与してください。（例: `import { example } from '../server/example.js';`）
+3. **VitestのAPI**:
+   テストの記述には `vitest` から `describe`, `it` (または `test`), `expect`, `vi` 等をインポートして使用してください。
+   ```typescript
+   import { describe, it, expect } from 'vitest';
+
+   describe('example feature', () => {
+     it('should work correctly', () => {
+       expect(1 + 1).toBe(2);
+     });
+   });
+   ```
+4. **モック化と非同期処理**:
+   - 外部へのリクエストや子プロセス生成など、副作用を伴うテストでは `vi.mock()` などを利用して適切にモック化してください。
+   - プロセスの起動やIPC通信などの非同期処理を待つ必要がある場合は、テストのタイムアウト時間（デフォルトは5秒）を超えないよう、必要に応じてタイムアウトを長めに設定（`it('...', async () => { ... }, 20000)` のように第3引数でミリ秒指定）してください。

--- a/tests/child-worker.test.ts
+++ b/tests/child-worker.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from 'vitest';
 import { spawn } from 'node:child_process';
 import net from 'node:net';
 import readline from 'node:readline';
@@ -10,44 +9,37 @@ test('Child Worker: startup, ready event, and handle request', async () => {
     const accountId = 'test-worker';
 
     // Child Worker 起動
-    const child = spawn('npx', ['tsx', 'server/child-worker.ts', `--account-id=${accountId}`, `--socket=${socketPath}`], {
-        stdio: 'ignore'
+    const child = spawn('./node_modules/.bin/tsx', ['server/child-worker.ts', `--account-id=${accountId}`, `--socket=${socketPath}`], {
+        stdio: 'inherit'
     });
 
     try {
-        // ソケットが作成されるまで待機
-        await new Promise((resolve, reject) => {
-            let retries = 0;
-            const interval = setInterval(() => {
+        let client: net.Socket | null = null;
+        let receivedReady = false;
+        let receivedResponse = false;
+        const messages: ChildMessage[] = [];
+
+        // ソケットが作成されるまでリトライしながら接続
+        const connect = async () => {
+            for (let i = 0; i < 100; i++) {
                 try {
-                    const client = net.connect(socketPath, () => {
-                        clearInterval(interval);
-                        resolve(client);
-                    });
-                    client.on('error', () => {
-                        retries++;
-                        if (retries > 100) {
-                            clearInterval(interval);
-                            reject(new Error('Socket connection timeout'));
-                        }
+                    return await new Promise<net.Socket>((resolve, reject) => {
+                        const s = net.connect(socketPath);
+                        s.on('connect', () => resolve(s));
+                        s.on('error', reject);
                     });
                 } catch (e) {
-                    // Ignore
+                    await new Promise(r => setTimeout(r, 100));
                 }
-            }, 100);
-        });
+            }
+            throw new Error('Socket connection timeout after 100 retries');
+        };
 
-        const client = net.createConnection(socketPath);
-
+        client = await connect();
         const rl = readline.createInterface({
             input: client,
             crlfDelay: Infinity
         });
-
-        let receivedReady = false;
-        let receivedResponse = false;
-
-        const messages: ChildMessage[] = [];
 
         rl.on('line', (line) => {
             if (!line.trim()) return;
@@ -56,7 +48,6 @@ test('Child Worker: startup, ready event, and handle request', async () => {
 
             if (msg.type === 'ready') {
                 receivedReady = true;
-                // Ready 受信後にリクエストを送信
                 const req: ParentMessage = {
                     type: 'request',
                     id: 'req-1',
@@ -64,27 +55,27 @@ test('Child Worker: startup, ready event, and handle request', async () => {
                     model: 'gemini-1.5-flash',
                     messages: [{ role: 'user', content: 'Hello API' }]
                 };
-                client.write(serializeIPCMessage(req));
+                client?.write(serializeIPCMessage(req));
             } else if (msg.type === 'error') {
-                // credential がないため、認証エラーなどが返るはず
                 receivedResponse = true;
             }
         });
 
-        // 最大10秒間、ready と response を待つ
-        await new Promise((resolve) => setTimeout(resolve, 10000));
+        // ready と response を待つ
+        const startTime = Date.now();
+        while (!(receivedReady && receivedResponse) && Date.now() - startTime < 15000) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
 
-        assert.strictEqual(receivedReady, true, 'Did not receive ready event from child worker');
-        assert.strictEqual(receivedResponse, true, 'Did not receive error response for invalid credentials from child worker');
+        expect(receivedReady).toBe(true);
+        expect(receivedResponse).toBe(true);
     } finally {
-        // クリーンアップ
         child.kill();
         try {
-            import('node:fs').then(fs => {
-                if (fs.existsSync(socketPath)) {
-                    fs.unlinkSync(socketPath);
-                }
-            });
+            const fs = await import('node:fs');
+            if (fs.existsSync(socketPath)) {
+                fs.unlinkSync(socketPath);
+            }
         } catch (e) { }
     }
-});
+}, 25000);

--- a/tests/ipc-protocol.test.ts
+++ b/tests/ipc-protocol.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from 'vitest';
 import { serializeIPCMessage, parseIPCMessage, type ParentMessage, type ChildMessage } from '../server/ipc-protocol.js';
 
 test('IPC Protocol: serialize and parse ParentMessage', () => {
@@ -12,10 +11,10 @@ test('IPC Protocol: serialize and parse ParentMessage', () => {
     };
 
     const serialized = serializeIPCMessage(msg);
-    assert.strictEqual(serialized.endsWith('\n'), true, 'Must end with newline');
+    expect(serialized.endsWith('\n')).toBe(true);
 
     const parsed = parseIPCMessage<ParentMessage>(serialized);
-    assert.deepStrictEqual(parsed, msg);
+    expect(parsed).toEqual(msg);
 });
 
 test('IPC Protocol: serialize and parse ChildMessage', () => {
@@ -27,7 +26,7 @@ test('IPC Protocol: serialize and parse ChildMessage', () => {
 
     const serialized = serializeIPCMessage(msg);
     const parsed = parseIPCMessage<ChildMessage>(serialized);
-    assert.deepStrictEqual(parsed, msg);
+    expect(parsed).toEqual(msg);
 });
 
 test('IPC Protocol: turn_end message', () => {
@@ -39,5 +38,5 @@ test('IPC Protocol: turn_end message', () => {
 
     const serialized = serializeIPCMessage(msg);
     const parsed = parseIPCMessage<ChildMessage>(serialized);
-    assert.deepStrictEqual(parsed, msg);
+    expect(parsed).toEqual(msg);
 });

--- a/tests/process-isolation.test.ts
+++ b/tests/process-isolation.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from 'vitest';
 import { childManager } from '../server/child-manager.js';
 
 test('Process Isolation: ChildManager can spawn multiple isolated workers concurrently', async () => {
@@ -11,21 +10,18 @@ test('Process Isolation: ChildManager can spawn multiple isolated workers concur
     // マネージャーの内部状態に両方のプロセスが登録されていることを確認
     const childrenMap = (childManager as any).children as Map<string, any>;
 
-    assert.strictEqual(childrenMap.has('test-isolation-A'), true, 'Account A should be running');
-    assert.strictEqual(childrenMap.has('test-isolation-B'), true, 'Account B should be running');
+    expect(childrenMap.has('test-isolation-A')).toBe(true);
+    expect(childrenMap.has('test-isolation-B')).toBe(true);
 
     const connectionA = childrenMap.get('test-isolation-A');
     const connectionB = childrenMap.get('test-isolation-B');
 
     // それぞれ別のプロセスIDを持っていることを検証（プロセスが分離されている証明）
-    assert.notStrictEqual(
-        connectionA.process.pid,
-        connectionB.process.pid,
-        'Child processes must have different strict PIDs'
-    );
+    expect(connectionA.process.pid).not.toBe(connectionB.process.pid);
 
     // クリーンアップ
     childManager.killAll();
 
-    assert.strictEqual(childrenMap.size, 0, 'Children map should be empty after killAll');
-});
+    expect(childrenMap.size).toBe(0);
+}, 20000); // Set timeout to 20s
+

--- a/tests/server/converters/request.test.ts
+++ b/tests/server/converters/request.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { mapModelName, convertMessagesToPrompt, extractSystemPrompt } from '../../../server/converters/request.js';
+import type { ClaudeMessage } from '../../../server/types.js';
+
+describe('request converter', () => {
+  describe('mapModelName', () => {
+    it('should map opus models to gemini-3.1-pro-preview', () => {
+      expect(mapModelName('claude-3-opus-20240229')).toBe('gemini-3.1-pro-preview');
+    });
+
+    it('should map sonnet models to gemini-3-flash-preview', () => {
+      expect(mapModelName('claude-3-5-sonnet-20240620')).toBe('gemini-3-flash-preview');
+    });
+
+    it('should map haiku models to gemini-2.5-flash-lite', () => {
+      expect(mapModelName('claude-3-haiku-20240307')).toBe('gemini-2.5-flash-lite');
+    });
+
+    it('should default to gemini-3-flash-preview for unknown non-gemini models', () => {
+      expect(mapModelName('gpt-4')).toBe('gemini-3-flash-preview');
+    });
+
+    it('should keep gemini models as is', () => {
+      expect(mapModelName('gemini-1.5-pro')).toBe('gemini-1.5-pro');
+    });
+  });
+
+  describe('extractSystemPrompt', () => {
+    it('should handle string system prompt', () => {
+      expect(extractSystemPrompt('You are a helpful assistant.')).toBe('You are a helpful assistant.');
+    });
+
+    it('should handle array of blocks', () => {
+      const system = [
+        { type: 'text', text: 'Line 1' },
+        'Line 2',
+        { type: 'text', text: 'Line 3' }
+      ];
+      expect(extractSystemPrompt(system)).toBe('Line 1\nLine 2\nLine 3');
+    });
+
+    it('should return undefined for empty system', () => {
+      expect(extractSystemPrompt(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('convertMessagesToPrompt', () => {
+    it('should convert single user message to raw text', () => {
+      const messages: ClaudeMessage[] = [
+        { role: 'user', content: 'Hello' }
+      ];
+      expect(convertMessagesToPrompt(messages)).toBe('Hello');
+    });
+
+    it('should convert multi-turn messages with role labels', () => {
+      const messages: ClaudeMessage[] = [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+        { role: 'user', content: 'How are you?' }
+      ];
+      const expected = 'User: Hello\n\nAssistant: Hi there!\n\nUser: How are you?';
+      expect(convertMessagesToPrompt(messages)).toBe(expected);
+    });
+
+    it('should handle complex content with tool use and results', () => {
+      const messages: ClaudeMessage[] = [
+        { role: 'user', content: 'What is the weather?' },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Let me check.' },
+            { type: 'tool_use', id: 'call_1', name: 'get_weather', input: { location: 'Tokyo' } }
+          ]
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'call_1', content: 'Sunny, 25C' }
+          ]
+        }
+      ];
+      const result = convertMessagesToPrompt(messages);
+      expect(result).toContain('User: What is the weather?');
+      expect(result).toContain('Assistant: Let me check.');
+      expect(result).toContain('[Tool Call: get_weather({"location":"Tokyo"})]');
+      expect(result).toContain('[Tool Result (call_1): Sunny, 25C]');
+    });
+  });
+});

--- a/tests/server/converters/stream.test.ts
+++ b/tests/server/converters/stream.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { streamGeminiToClaudeSSE, setupSSEHeaders } from '../../../server/converters/stream.js';
+import type { Response } from 'express';
+
+describe('stream converter', () => {
+  describe('setupSSEHeaders', () => {
+    it('should set SSE headers', () => {
+      const res = {
+        setHeader: vi.fn(),
+        flushHeaders: vi.fn(),
+      } as unknown as Response;
+
+      setupSSEHeaders(res);
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+      expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-cache');
+      expect(res.setHeader).toHaveBeenCalledWith('Connection', 'keep-alive');
+      expect(res.flushHeaders).toHaveBeenCalled();
+    });
+  });
+
+  describe('streamGeminiToClaudeSSE', () => {
+    it('should correctly stream text content', async () => {
+      const mockRes = {
+        setHeader: vi.fn(),
+        flushHeaders: vi.fn(),
+        write: vi.fn(),
+        end: vi.fn(),
+        writableEnded: false,
+      } as unknown as Response;
+
+      // Mock Child process stream
+      async function* mockChildStream() {
+        yield { type: 'stream_event', event: { type: 'content', value: 'Hello' } };
+        yield { type: 'stream_event', event: { type: 'content', value: ' world!' } };
+        yield { type: 'turn_end', stopReason: 'end_turn', usage: { output_tokens: 10 } };
+      }
+
+      const mockSessionStore = {
+        addPendingToolCall: vi.fn(),
+      } as any;
+
+      await streamGeminiToClaudeSSE(mockChildStream(), mockRes, 'test-model', 'sess-1', mockSessionStore, []);
+
+      // Verify SSE events were sent
+      const writes = (mockRes.write as any).mock.calls.map((call: [string]) => call[0]);
+      expect(writes.some((w: string) => w.includes('message_start'))).toBe(true);
+      expect(writes.some((w: string) => w.includes('content_block_start'))).toBe(true);
+      expect(writes.some((w: string) => w.includes('text_delta') && w.includes('Hello'))).toBe(true);
+      expect(writes.some((w: string) => w.includes('text_delta') && w.includes(' world!'))).toBe(true);
+      expect(writes.some((w: string) => w.includes('message_delta') && w.includes('end_turn'))).toBe(true);
+      expect(writes.some((w: string) => w.includes('message_stop'))).toBe(true);
+      expect(mockRes.end).toHaveBeenCalled();
+    });
+
+    it('should correctly stream tool calls', async () => {
+      const mockRes = {
+        setHeader: vi.fn(),
+        flushHeaders: vi.fn(),
+        write: vi.fn(),
+        end: vi.fn(),
+        writableEnded: false,
+      } as unknown as Response;
+
+      // Mock Child process stream with tool call
+      async function* mockChildStream() {
+        yield { type: 'tool_call', callId: 'call_1', name: 'get_weather', args: { location: 'Tokyo' } };
+        yield { type: 'turn_end', stopReason: 'tool_use', usage: { output_tokens: 5 } };
+      }
+
+      const mockSessionStore = {
+        addPendingToolCall: vi.fn(),
+      } as any;
+
+      await streamGeminiToClaudeSSE(mockChildStream(), mockRes, 'test-model', 'sess-1', mockSessionStore, ['get_weather']);
+
+      // Verify tool call SSE events
+      const writes = (mockRes.write as any).mock.calls.map((call: [string]) => call[0]);
+      expect(writes.some((w: string) => w.includes('tool_use') && w.includes('get_weather'))).toBe(true);
+      expect(writes.some((w: string) => w.includes('input_json_delta') && w.includes('Tokyo'))).toBe(true);
+      expect(mockSessionStore.addPendingToolCall).toHaveBeenCalledWith('sess-1', 'call_1');
+    });
+
+    it('should handle errors in the child stream', async () => {
+        const mockRes = {
+          setHeader: vi.fn(),
+          flushHeaders: vi.fn(),
+          write: vi.fn(),
+          end: vi.fn(),
+          writableEnded: false,
+        } as unknown as Response;
+
+        // Mock child stream with error
+        async function* mockChildStream() {
+          yield { type: 'error', message: 'API failure', status: 500 };
+        }
+
+        const mockSessionStore = {
+          addPendingToolCall: vi.fn(),
+        } as any;
+
+        await streamGeminiToClaudeSSE(mockChildStream(), mockRes, 'test-model', 'sess-1', mockSessionStore, []);
+
+        const writes = (mockRes.write as any).mock.calls.map((call: [string]) => call[0]);
+        expect(writes.some((w: string) => w.includes('event: error') && w.includes('API failure'))).toBe(true);
+        expect(mockRes.end).toHaveBeenCalled();
+      });
+  });
+});

--- a/tests/server/converters/tool-schema.test.ts
+++ b/tests/server/converters/tool-schema.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { jsonSchemaToZod } from '../../../server/converters/tool-schema.js';
+import { z } from 'zod';
+
+describe('tool-schema converter', () => {
+  describe('jsonSchemaToZod', () => {
+    it('should convert string schema', () => {
+      const schema = { type: 'string', description: 'A name' };
+      const zodType = jsonSchemaToZod(schema);
+      expect(zodType instanceof z.ZodString).toBe(true);
+      expect(zodType.description).toBe('A name');
+      expect(zodType.parse('John')).toBe('John');
+    });
+
+    it('should convert integer schema', () => {
+      const schema = { type: 'integer' };
+      const zodType = jsonSchemaToZod(schema);
+      expect(zodType instanceof z.ZodNumber).toBe(true);
+      expect(zodType.parse(42)).toBe(42);
+      expect(() => zodType.parse(3.14)).toThrow();
+    });
+
+    it('should convert object schema with properties and required fields', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' }
+        },
+        required: ['name']
+      };
+      const zodType = jsonSchemaToZod(schema);
+      expect(zodType instanceof z.ZodObject).toBe(true);
+
+      // name is required
+      expect(zodType.parse({ name: 'John' })).toEqual({ name: 'John' });
+      expect(() => zodType.parse({ age: 30 })).toThrow();
+
+      // age is optional
+      expect(zodType.parse({ name: 'John', age: 30 })).toEqual({ name: 'John', age: 30 });
+    });
+
+    it('should convert array schema', () => {
+      const schema = {
+        type: 'array',
+        items: { type: 'string' }
+      };
+      const zodType = jsonSchemaToZod(schema);
+      expect(zodType instanceof z.ZodArray).toBe(true);
+      expect(zodType.parse(['a', 'b'])).toEqual(['a', 'b']);
+      expect(() => zodType.parse([1, 2])).toThrow();
+    });
+
+    it('should convert enum schema', () => {
+      const schema = {
+        type: 'string',
+        enum: ['red', 'green', 'blue']
+      };
+      const zodType = jsonSchemaToZod(schema);
+      expect(zodType instanceof z.ZodEnum).toBe(true);
+      expect(zodType.parse('red')).toBe('red');
+      expect(() => zodType.parse('yellow')).toThrow();
+    });
+  });
+});

--- a/tests/server/routes/messages.test.ts
+++ b/tests/server/routes/messages.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { messagesRouter } from '../../../server/routes/messages.js';
+import { accountPool } from '../../../server/account-pool.js';
+import { childManager } from '../../../server/child-manager.js';
+
+// Mock dependencies
+vi.mock('../../../server/account-pool.js', () => ({
+  accountPool: {
+    nextAccount: vi.fn(),
+    getAccountCount: vi.fn(),
+    initialize: vi.fn(),
+  }
+}));
+
+vi.mock('../../../server/child-manager.js', () => ({
+  childManager: {
+    sendRequest: vi.fn(),
+    onMessage: vi.fn(() => vi.fn()),
+    onChildExit: vi.fn(() => vi.fn()),
+  }
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/v1/messages', messagesRouter);
+
+describe('messages router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return 400 if messages are missing', async () => {
+    const response = await request(app)
+      .post('/v1/messages')
+      .send({ model: 'claude-3-sonnet' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.message).toContain('messages are required');
+  });
+
+  it('should return 400 if model is missing', async () => {
+    const response = await request(app)
+      .post('/v1/messages')
+      .send({ messages: [{ role: 'user', content: 'Hello' }] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.message).toContain('model is required');
+  });
+
+  it('should handle a successful non-streaming request', async () => {
+    vi.mocked(accountPool.nextAccount).mockReturnValue('test-account');
+
+    let capturedHandler: any;
+    vi.mocked(childManager.onMessage).mockImplementation((accountId, handler) => {
+      capturedHandler = handler;
+      return vi.fn();
+    });
+
+    vi.mocked(childManager.sendRequest).mockImplementation(async (accountId, msg) => {
+      const sessionId = (msg as any).sessionId;
+      if (capturedHandler) {
+        // Send messages using a slight delay to ensure the router is ready
+        setTimeout(() => {
+          capturedHandler({
+            type: 'stream_event',
+            sessionId,
+            event: { type: 'content', value: 'Hello from Gemini!' }
+          });
+          capturedHandler({
+            type: 'turn_end',
+            sessionId,
+            stopReason: 'end_turn',
+            usage: { input_tokens: 10, output_tokens: 5 }
+          });
+        }, 100);
+      }
+    });
+
+    const response = await request(app)
+      .post('/v1/messages')
+      .send({
+        model: 'claude-3-sonnet',
+        messages: [{ role: 'user', content: 'Hi' }],
+        stream: false
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.type).toBe('message');
+    expect(response.body.content[0].text).toBe('Hello from Gemini!');
+    expect(response.body.usage.output_tokens).toBe(5);
+  });
+
+  it('should handle errors from child process', async () => {
+    vi.mocked(accountPool.nextAccount).mockReturnValue('test-account');
+
+    let capturedHandler: any;
+    vi.mocked(childManager.onMessage).mockImplementation((accountId, handler) => {
+      capturedHandler = handler;
+      return vi.fn();
+    });
+
+    vi.mocked(childManager.sendRequest).mockImplementation(async (accountId, msg) => {
+      const sessionId = (msg as any).sessionId;
+      if (capturedHandler) {
+        setTimeout(() => {
+          capturedHandler({
+            type: 'error',
+            sessionId,
+            message: 'Something went wrong',
+            status: 500
+          });
+        }, 100);
+      }
+    });
+
+    const response = await request(app)
+      .post('/v1/messages')
+      .send({
+        model: 'claude-3-sonnet',
+        messages: [{ role: 'user', content: 'Hi' }]
+      });
+
+    expect(response.status).toBe(500);
+    expect(response.body.error.message).toContain('Gemini API error: Something went wrong');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    exclude: ['gemini-cli/**', 'node_modules/**'],
+  },
+});


### PR DESCRIPTION
## Summary
This PR introduces the **Vitest** testing framework to replace the previous `node:test` setup, providing better support for the project's TypeScript and ESM architecture. It also expands the overall testing coverage by adding unit tests for converters and API integration tests for the messages route.

Key changes:
- Switched from `node:test` to `Vitest` in all existing tests.
- Added unit tests for `request`, `stream`, and `tool-schema` converters in `server/converters/`.
- Added API integration tests for `server/routes/messages.ts` using `supertest`.
- Updated `server/child-manager.ts` to correctly handle `tsx` spawning for `.ts` files in test environments.
- Added `vitest.config.ts` to manage test execution scope.

## Test plan
- [x] Run `npm run test` to verify all 29 tests pass.
- [x] Verified that existing process isolation and IPC tests correctly run under Vitest.
- [x] Confirmed new converter unit tests accurately validate conversion logic.
- [x] Confirmed API integration tests correctly mock the child worker environment.