### PR TITLE
fix: 複数ツール同時呼び出し時のデッドロックを修正

### DIFF
--- a/server/child-worker.ts
+++ b/server/child-worker.ts
@@ -52,8 +52,6 @@ interface ToolState {
     callIds: Map<string, string[]>;
     resolveToolTurn?: () => void;
     expectedClientTools: number;
-    registeredClientTools: number;
-    hasYieldedFinished: boolean;
 }
 
 interface PendingToolCall {
@@ -245,9 +243,7 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
                 // 新規作成
                 toolState = {
                     callIds: new Map(),
-                    expectedClientTools: 0,
-                    registeredClientTools: 0,
-                    hasYieldedFinished: false
+                    expectedClientTools: 0
                 };
                 sessionData.toolState = toolState;
 
@@ -266,7 +262,6 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
                         const earlyResult = sessionData.earlyToolResults.get(callId);
                         if (earlyResult !== undefined) {
                             sessionData.earlyToolResults.delete(callId);
-                            toolState!.registeredClientTools++;
                             return earlyResult;
                         }
 
@@ -278,8 +273,6 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
                                 resolve,
                                 reject,
                             });
-
-                            toolState!.registeredClientTools++;
                         });
                     }
                 ));
@@ -427,8 +420,6 @@ async function consumeStream(
     // 前ターンのツール状態をリセット
     // callIdsはSDKのコールバック内でshift()により消費されるためclear()不要
     toolState.expectedClientTools = 0;
-    toolState.registeredClientTools = 0;
-    toolState.hasYieldedFinished = false;
 
     let isToolTurnReached = false;
     let turnPromiseResolve: () => void;
@@ -488,7 +479,6 @@ async function consumeStream(
                         output_tokens: usage.candidatesTokenCount || 0,
                     };
                 }
-                toolState.hasYieldedFinished = true;
                 // finished時点で全tool_call_requestは処理済み。
                 // SDK Schedulerはツールを順次実行するため、registeredClientToolsの
                 // 完了を待つとデッドロックする。expectedClientTools > 0 なら即座にターン終了。

--- a/server/child-worker.ts
+++ b/server/child-worker.ts
@@ -68,6 +68,7 @@ interface SessionData {
     stream?: AsyncGenerator<ServerGeminiStreamEvent, any, any>;
     pendingNext?: Promise<IteratorResult<ServerGeminiStreamEvent, any>>;
     pendingToolCalls: Map<string, PendingToolCall>;
+    earlyToolResults: Map<string, unknown>;
     toolState?: ToolState;
     lastUsage?: {
         input_tokens: number;
@@ -80,7 +81,7 @@ const sessionStore = new Map<string, SessionData>();
 function getOrCreateSession(sessionId: string): SessionData {
     let session = sessionStore.get(sessionId);
     if (!session) {
-        session = { pendingToolCalls: new Map() };
+        session = { pendingToolCalls: new Map(), earlyToolResults: new Map() };
         sessionStore.set(sessionId, session);
     }
     return session;
@@ -261,6 +262,14 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
                         const callId = callIds?.shift();
                         if (!callId) throw new Error(`callId not found for tool ${t.name}`);
 
+                        // 先行して到着済みの結果があればキャッシュから即座に返す
+                        const earlyResult = sessionData.earlyToolResults.get(callId);
+                        if (earlyResult !== undefined) {
+                            sessionData.earlyToolResults.delete(callId);
+                            toolState!.registeredClientTools++;
+                            return earlyResult;
+                        }
+
                         return new Promise((resolve, reject) => {
                             sessionData.pendingToolCalls.set(callId, {
                                 toolCallId: callId,
@@ -390,7 +399,8 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
             pendingCall.resolve(result);
             sessionData.pendingToolCalls.delete(toolCallId);
         } else {
-            console.warn(`[Child Worker ${accountId}] Pending tool call not found: ${toolCallId}`);
+            // SDKがまだツールを登録していない場合、結果をキャッシュしておく
+            sessionData.earlyToolResults.set(toolCallId, result);
         }
     } else if (msg.type === 'resume_stream') {
         const { sessionId } = msg;

--- a/server/child-worker.ts
+++ b/server/child-worker.ts
@@ -275,11 +275,6 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
                             });
 
                             toolState!.registeredClientTools++;
-                            if (toolState!.hasYieldedFinished &&
-                                toolState!.registeredClientTools >= toolState!.expectedClientTools &&
-                                toolState!.resolveToolTurn) {
-                                toolState!.resolveToolTurn();
-                            }
                         });
                     }
                 ));
@@ -409,6 +404,12 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
             return;
         }
 
+        // 新しいターン用にツール状態をリセット
+        sessionData.toolState.callIds.clear();
+        sessionData.toolState.expectedClientTools = 0;
+        sessionData.toolState.registeredClientTools = 0;
+        sessionData.toolState.hasYieldedFinished = false;
+
         // ストリーム消費ループを再開
         consumeStream(sessionData.stream, sessionData.toolState, sessionId, sessionData, sendEvent);
     }
@@ -481,9 +482,10 @@ async function consumeStream(
                     };
                 }
                 toolState.hasYieldedFinished = true;
-                if (toolState.expectedClientTools > 0 &&
-                    toolState.registeredClientTools >= toolState.expectedClientTools &&
-                    toolState.resolveToolTurn) {
+                // finished時点で全tool_call_requestは処理済み。
+                // SDK Schedulerはツールを順次実行するため、registeredClientToolsの
+                // 完了を待つとデッドロックする。expectedClientTools > 0 なら即座にターン終了。
+                if (toolState.expectedClientTools > 0 && toolState.resolveToolTurn) {
                     toolState.resolveToolTurn();
                 }
             } else if (chunk.type === 'tool_call_request') {

--- a/server/child-worker.ts
+++ b/server/child-worker.ts
@@ -68,8 +68,6 @@ interface SessionData {
     stream?: AsyncGenerator<ServerGeminiStreamEvent, any, any>;
     pendingNext?: Promise<IteratorResult<ServerGeminiStreamEvent, any>>;
     pendingToolCalls: Map<string, PendingToolCall>;
-    // SDKがツールを登録する前に結果が届いた場合の一時キャッシュ
-    earlyToolResults: Map<string, unknown>;
     toolState?: ToolState;
     lastUsage?: {
         input_tokens: number;
@@ -82,7 +80,7 @@ const sessionStore = new Map<string, SessionData>();
 function getOrCreateSession(sessionId: string): SessionData {
     let session = sessionStore.get(sessionId);
     if (!session) {
-        session = { pendingToolCalls: new Map(), earlyToolResults: new Map() };
+        session = { pendingToolCalls: new Map() };
         sessionStore.set(sessionId, session);
     }
     return session;
@@ -241,11 +239,7 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
             let toolState = sessionData.toolState;
 
             if (stream && toolState) {
-                // 再利用
-                toolState.callIds.clear();
-                toolState.expectedClientTools = 0;
-                toolState.registeredClientTools = 0;
-                toolState.hasYieldedFinished = false;
+                // 再利用 - リセットは consumeStream 冒頭で行う
             } else {
                 // 新規作成
                 toolState = {
@@ -266,14 +260,6 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
                         const callIds = toolState!.callIds.get(t.name);
                         const callId = callIds?.shift();
                         if (!callId) throw new Error(`callId not found for tool ${t.name}`);
-
-                        // SDKの直列実行により、結果がツール登録より先に届いている場合がある
-                        if (sessionData.earlyToolResults.has(callId)) {
-                            const result = sessionData.earlyToolResults.get(callId);
-                            sessionData.earlyToolResults.delete(callId);
-                            toolState!.registeredClientTools++;
-                            return result;
-                        }
 
                         return new Promise((resolve, reject) => {
                             sessionData.pendingToolCalls.set(callId, {
@@ -404,8 +390,7 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
             pendingCall.resolve(result);
             sessionData.pendingToolCalls.delete(toolCallId);
         } else {
-            // SDKの直列実行により、まだツールが登録されていない場合はキャッシュしておく
-            sessionData.earlyToolResults.set(toolCallId, result);
+            console.warn(`[Child Worker ${accountId}] Pending tool call not found: ${toolCallId}`);
         }
     } else if (msg.type === 'resume_stream') {
         const { sessionId } = msg;
@@ -415,11 +400,6 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
             return;
         }
 
-        // 新しいターン用にツール状態をリセット
-        sessionData.toolState.callIds.clear();
-        sessionData.toolState.expectedClientTools = 0;
-        sessionData.toolState.registeredClientTools = 0;
-        sessionData.toolState.hasYieldedFinished = false;
 
         // ストリーム消費ループを再開
         consumeStream(sessionData.stream, sessionData.toolState, sessionId, sessionData, sendEvent);
@@ -434,6 +414,12 @@ async function consumeStream(
     sessionData: SessionData,
     sendEvent: (msg: ChildMessage) => void
 ) {
+    // 前ターンのツール状態をリセット
+    // callIdsはSDKのコールバック内でshift()により消費されるためclear()不要
+    toolState.expectedClientTools = 0;
+    toolState.registeredClientTools = 0;
+    toolState.hasYieldedFinished = false;
+
     let isToolTurnReached = false;
     let turnPromiseResolve: () => void;
     const turnPromise = new Promise<void>((resolve) => { turnPromiseResolve = resolve; });

--- a/server/child-worker.ts
+++ b/server/child-worker.ts
@@ -68,6 +68,8 @@ interface SessionData {
     stream?: AsyncGenerator<ServerGeminiStreamEvent, any, any>;
     pendingNext?: Promise<IteratorResult<ServerGeminiStreamEvent, any>>;
     pendingToolCalls: Map<string, PendingToolCall>;
+    // SDKがツールを登録する前に結果が届いた場合の一時キャッシュ
+    earlyToolResults: Map<string, unknown>;
     toolState?: ToolState;
     lastUsage?: {
         input_tokens: number;
@@ -80,7 +82,7 @@ const sessionStore = new Map<string, SessionData>();
 function getOrCreateSession(sessionId: string): SessionData {
     let session = sessionStore.get(sessionId);
     if (!session) {
-        session = { pendingToolCalls: new Map() };
+        session = { pendingToolCalls: new Map(), earlyToolResults: new Map() };
         sessionStore.set(sessionId, session);
     }
     return session;
@@ -265,6 +267,14 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
                         const callId = callIds?.shift();
                         if (!callId) throw new Error(`callId not found for tool ${t.name}`);
 
+                        // SDKの直列実行により、結果がツール登録より先に届いている場合がある
+                        if (sessionData.earlyToolResults.has(callId)) {
+                            const result = sessionData.earlyToolResults.get(callId);
+                            sessionData.earlyToolResults.delete(callId);
+                            toolState!.registeredClientTools++;
+                            return result;
+                        }
+
                         return new Promise((resolve, reject) => {
                             sessionData.pendingToolCalls.set(callId, {
                                 toolCallId: callId,
@@ -394,7 +404,8 @@ async function handleParentMessage(msg: ParentMessage, sendEvent: (msg: ChildMes
             pendingCall.resolve(result);
             sessionData.pendingToolCalls.delete(toolCallId);
         } else {
-            console.warn(`[Child Worker ${accountId}] Pending tool call not found: ${toolCallId}`);
+            // SDKの直列実行により、まだツールが登録されていない場合はキャッシュしておく
+            sessionData.earlyToolResults.set(toolCallId, result);
         }
     } else if (msg.type === 'resume_stream') {
         const { sessionId } = msg;


### PR DESCRIPTION
## 概要
Claude Code 等で複数ツールを同時に呼び出すリクエストが行われた際（Geminiが1レスポンスで複数ツールを呼んだ場合）、SDK Schedulerがツールを順次実行するため、`consumeStream` の `registeredClientTools` が全て揃うのを待つロジックと競合してデッドロックが発生する問題を修正しました。

## 修正内容
- `finished` ハンドラにおいて、`expectedClientTools > 0` の場合は即座に `resolveToolTurn()` を呼び出してターンを終了するよう変更しました。
  - この時点で全 `tool_call_request` は処理済みであり、SDK はツールを順次実行するため、全てのツールの完了を待つとデッドロックになります。
- ツールコールバック内の不要になった `resolveToolTurn()` チェックを削除しました。
- `resume_stream` ハンドラで、新しいターンに向けて `toolState` をリセットする処理を追加しました。